### PR TITLE
Exit code 1 on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ exports.process = (bucket, domain, environment) => {
 
 exports.error = (message) => {
   spinner.fail(message)
-  process.exit()
+  process.exit(1)
 }
 exports.succeed = () => { spinner.succeed() }
 exports.info = () => { spinner.info() }


### PR DESCRIPTION
If you use scripts to deploy you cannot detect if there was an error on this one and stop everything.